### PR TITLE
fix: font rendering

### DIFF
--- a/style.css
+++ b/style.css
@@ -3,6 +3,7 @@
     src: url('fredoka.woff2') format('woff2');
     font-weight: 300 500;
     font-style: normal;
+    font-display: swap;
 }
 
 *{


### PR DESCRIPTION
i'm literally just adding one line.
the font is preloaded but by default it's still hidden until fully downloaded.
this will make that 1.4s LCP go away.

![image](https://github.com/AuroraNemoia/unikara-web/assets/36823200/2f0e8b4c-8194-4deb-a9b1-dcbfab15ef0a)
